### PR TITLE
add -D__BPF_TRACING__ to fix 'Clang is too old' error

### DIFF
--- a/internal/bpf/Makefile
+++ b/internal/bpf/Makefile
@@ -8,6 +8,7 @@ define BASEFLAGS
 		  -include $(KERNELDIR)/include/linux/kconfig.h  \
 		  -include asm_goto_workaround.h                 \
 		  -D__KERNEL__                                   \
+		  -D__BPF_TRACING__                              \
 		  -Wno-gnu-variable-sized-type-not-at-end        \
 		  -Wno-address-of-packed-member                  \
 		  -fno-jump-tables                               \


### PR DESCRIPTION
When running `make bpf`, clang failed with 

```
In file included from /kernel/include/linux/compiler_types.h:69:
/kernel/include/linux/compiler-clang.h:12:3: error: Sorry, your version of Clang is too old - please use 10.0.1 or newer.
# error Sorry, your version of Clang is too old - please use 10.0.1 or newer.
```
@ycamper shared https://www.spinics.net/lists/kernel/msg3738363.html. Sure enough, in `/usr/lib/modules/5.10.13-arch1-1/build/include/linux/compiler-clang.h` is the same line: 

```
if CLANG_VERSION < 100001
#ifndef __BPF_TRACING__
# error Sorry, your version of Clang is too old - please use 10.0.1 or newer.
#endif
```

so adding the `-D__BPF_TRACING__` worked, as suggested in the link and slack thread. Committing the changes here.
